### PR TITLE
Call parent iterators hasNext as late as possible when simpler checks exist

### DIFF
--- a/src/main/java/groovy/stream/iterators/LimitedIterator.java
+++ b/src/main/java/groovy/stream/iterators/LimitedIterator.java
@@ -29,7 +29,7 @@ public class LimitedIterator<T> implements Iterator<T> {
 
     @Override
     public boolean hasNext() {
-        return delegate.hasNext() && limit > 0 ;
+        return limit > 0 && delegate.hasNext() ;
     }
 
     @Override

--- a/src/main/java/groovy/stream/iterators/RepeatingIterator.java
+++ b/src/main/java/groovy/stream/iterators/RepeatingIterator.java
@@ -44,7 +44,7 @@ public class RepeatingIterator<T> implements Iterator<T> {
 
     @Override
     public boolean hasNext() {
-        return current.hasNext() || nRepeats == FOREVER || nRepeats > 1;
+        return nRepeats == FOREVER || nRepeats > 1 || current.hasNext();
     }
 
     @Override


### PR DESCRIPTION
I expect the `LimitedIterator` to only call the `hasNext()` method for the delegate a maximum of `N` times where `N` is the number of elements to take. If the iterator represents some expensive operations, or an unexhausted infinite stream that has exactly `N` elements available, the `LimitedIterator` will block waiting for the `Nth+1` element only to return `N` of them.  Same goes for `RepeatingIterator`